### PR TITLE
refacto(webpack_config): Remove cleaning duplicate

### DIFF
--- a/webpack_config/client/webpack.prod.babel.js
+++ b/webpack_config/client/webpack.prod.babel.js
@@ -12,9 +12,6 @@ import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer'
 import base from './webpack.base'
 import config from '../config'
 
-// Clean build dir
-rimraf(`${config.distPath}/client`, {}, () => {})
-
 // Do you want to use bundle analyzer?
 if (config.ANALYZE_BUNDLE) {
 	base.plugins.push(new BundleAnalyzerPlugin({analyzerMode: 'static'}))


### PR DESCRIPTION
Remove the dist/client cleaning instruction because it's already done into `webpack_config/client/webpack.base.js`.